### PR TITLE
Stack build and Travis configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.stack-work

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,37 @@
+# For further information on this Travis setup:
+#   http://docs.haskellstack.org/en/stable/GUIDE.html#travis-with-caching
+
+# use new container infrastructure to allow caching
+sudo: false
+
+# choose light-weight base image
+language: c
+
+addons:
+  apt:
+    packages:
+    - libgmp-dev      # for ghc
+    - libxxf86vm-dev  # for GLFW
+
+# different configurations:
+env:
+  - ARGS="--resolver nightly-2016-01-22"
+
+before_install:
+# Download and unpack the stack executable
+- mkdir -p ~/.local/bin
+- export PATH=$HOME/.local/bin:$PATH
+- travis_retry curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
+# Setup stack
+- stack --no-terminal setup
+# Install hscolour to remove some haddock warnings; try removing when 
+# changing to a stable Stack resolver.
+- stack --no-terminal install hscolour
+
+# build
+script: stack $ARGS --no-terminal --install-ghc test --haddock
+
+# set up caching
+cache:
+  directories:
+  - $HOME/.stack

--- a/README.md
+++ b/README.md
@@ -1,9 +1,33 @@
 # gpipe-quake3
 
-PAK0.PK3 file is needed, get it from quake3 demo version
+[![Build Status](https://travis-ci.org/csabahruska/gpipe-quake3.svg?branch=master)](
+  https://travis-ci.org/csabahruska/gpipe-quake3)
 
-cabal install
+> Quake 3 level viewer in Haskell using GPipe.
 
-gpipe-quake3 q3dm1
+`PAK0.PK3` file is needed, get it from the Quake3 demo version.
+
+```
+$ cabal install
+$ gpipe-quake3 q3dm1
+```
 
 ![Quake III level viewer](https://raw.githubusercontent.com/csabahruska/gpipe-quake3/master/qpipe-quake3.jpg)
+
+## Optional: Stack build
+
+Stack can be used to build the viewer with minimal dependencies:
+
+1. Fetch the latest [stack](http://haskellstack.org/) tool.
+2. Build using stack (this will fetch the ghc Haskell compiler if necessary, 
+   and all dependencies):
+
+    ```
+    $ stack build
+    ```
+
+3. Run using stack:
+
+    ```
+    $ stack exec gpipe-quake3 -- q3dm1
+    ```

--- a/gpipe-quake3.cabal
+++ b/gpipe-quake3.cabal
@@ -36,7 +36,7 @@ executable gpipe-quake3
                        mmap >=0.5 && <0.6,
                        zlib >=0.6 && <0.7,
                        GLFW-b >= 1.4 && <1.5,
-                       lens >= 4.12 && <4.13,
+                       lens >= 4.12 && <4.14,
                        GPipe-GLFW >= 1.2 && <1.3,
                        JuicyPixels >=3.2 && <3.3,
                        exception-transformers >= 0.4 && <0.5

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,35 @@
+# For more information, see: http://docs.haskellstack.org/en/stable/yaml_configuration.html
+
+# Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
+resolver: nightly-2016-01-22
+
+# Local packages, usually specified by relative directory name
+packages:
+- '.'
+
+# Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
+extra-deps: []
+
+# Override default flag values for local packages and extra-deps
+flags: {}
+
+# Extra package databases containing global packages
+extra-package-dbs: []
+
+# Control whether we use the GHC we find on the path
+# system-ghc: true
+
+# Require a specific version of stack, using version ranges
+# require-stack-version: -any # Default
+# require-stack-version: >= 1.0.0
+
+# Override the architecture used by stack, especially useful on Windows
+# arch: i386
+# arch: x86_64
+
+# Extra directories used by stack for building
+# extra-include-dirs: [/path/to/dir]
+# extra-lib-dirs: [/path/to/dir]
+
+# Allow a newer minor version of GHC than the snapshot specifies
+# compiler-check: newer-minor


### PR DESCRIPTION
This PR contains a build setup for stack and a Travis build configuration.

Also includes:
- minor reformatting of `README.md` and addition of stack build instructions
- bump of `lens` to the version contained in the stack `nightly-2016-01-22` resolver

---

Some advantages of stack:
https://www.fpcomplete.com/blog/2015/06/announcing-first-public-beta-stack

Advantages of a Travis build:
- assures people that the current git state on master compiles,
- can check that branches build before merging,
- (checks that any test suites run)

Please feel absolutely free to decline if you aren't fans of stack or Travis (and/or have something else in mind).

The Travis build will have to be enabled manually by the repository owner at http://travis-ci.org (AFAIK, that's not something that can be done in a PR). However, a Travis build setup is included (`.travis.yml`) that completes successfully in my test branch.
