### PR TITLE
Bumping versions to work with GPipe 2.2.3, that fixes rendering issues

### DIFF
--- a/gpipe-quake3.cabal
+++ b/gpipe-quake3.cabal
@@ -19,7 +19,7 @@ executable gpipe-quake3
   main-is:             Main.hs
   -- other-modules:
   other-extensions:    OverloadedStrings, TypeOperators, DataKinds, PackageImports, TupleSections, ScopedTypeVariables, TypeFamilies, FlexibleContexts, RecordWildCards
-  build-depends:       base >=4.8 && <4.10,
+  build-depends:       base >=4.8 && <4.11,
                        binary >=0.7 && <0.9,
                        data-binary-ieee754 >=0.4 && <0.5,
                        linear >= 1.20 && <1.21,

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,7 @@
 # For more information, see: http://docs.haskellstack.org/en/stable/yaml_configuration.html
 
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-resolver: nightly-2017-04-23
+resolver: nightly-2017-09-20
 
 # Local packages, usually specified by relative directory name
 packages:
@@ -9,8 +9,10 @@ packages:
 
 # Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
 extra-deps:
-- GPipe-GLFW-1.4.1
-- GPipe-2.2.1
+- GPipe-2.2.3
+- GPipe-GLFW-1.4.1.1
+- GLFW-b-1.4.8.1
+- bindings-GLFW-3.1.2.3
 
 # Override default flag values for local packages and extra-deps
 flags: {}


### PR DESCRIPTION
Hi,

I figured out why rendering of shadows was broken after GPipe 2.2 (which @plredmond updated gpipe-quake3 for).  In addition, I bumped it to use GHC 8.2.1. Now it renders nicely again!